### PR TITLE
Adding option to convert TimeTick to Integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## Unreleased
+### Added
+- Option to convert SNMP Timetick data to Integer for easier comparisons
 
 ## [0.1.0] - 2015-11-13
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Option to convert SNMP Timetick data to Integer for easier comparisons
 
 ## [0.1.0] - 2015-11-13
 ### Added

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -61,8 +61,10 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          default: 'ge'
 
   option :convert_timeticks,
-         short: '-T (true|false)',
-         description: 'Convert SNMP::TimeTick to Integer for comparisons',
+         short: '-T',
+         long: '--convert-timeticks',
+         description: 'Convert SNMP::TimeTicks to Integer for comparisons',
+         boolean: true,
          default: 'false'
 
   option :timeout,
@@ -92,7 +94,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
           critical "Value: #{vb.value} failed to match Pattern: #{config[:match]}"
         end
       else
-        snmp_value =  if config[:convert_timeticks] && config[:convert_timeticks] == 'true'
+        snmp_value =  if config[:convert_timeticks]
                         vb.value.is_a?(SNMP::TimeTicks) ? vb.value.to_i : vb.value
                       else
                         vb.value

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -60,6 +60,11 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          description: 'Operator used to compare data with warning/critial values. Can be set to "le" (<=), "ge" (>=).',
          default: 'ge'
 
+  option :convert_timeticks,
+         short: '-T (true|false)',
+         description: 'Convert SNMP::TimeTick to Integer for comparisons',
+         default: 'false'
+
   option :timeout,
          short: '-t timeout (seconds)',
          default: '1'
@@ -87,10 +92,16 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
           critical "Value: #{vb.value} failed to match Pattern: #{config[:match]}"
         end
       else
-        critical 'Critical state detected' if vb.value.to_s.to_i.send(symbol, config[:critical].to_s.to_i)
+        snmp_value =  if config[:convert_timeticks] && config[:convert_timeticks] == 'true'
+                        vb.value.is_a?(SNMP::TimeTicks) ? vb.value.to_i : vb.value
+                      else
+                        vb.value
+                      end
+
+        critical 'Critical state detected' if snmp_value.to_s.to_i.send(symbol, config[:critical].to_s.to_i)
         # #YELLOW
-        warning 'Warning state detected' if vb.value.to_s.to_i.send(symbol, config[:warning].to_s.to_i) && !vb.value.to_s.to_i.send(symbol, config[:critical].to_s.to_i) # rubocop:disable LineLength
-        unless vb.value.to_s.to_i.send(symbol, config[:warning].to_s.to_i)
+        warning 'Warning state detected' if snmp_value.to_s.to_i.send(symbol, config[:warning].to_s.to_i) && !snmp_value.to_s.to_i.send(symbol, config[:critical].to_s.to_i) # rubocop:disable LineLength
+        unless snmp_value.to_s.to_i.send(symbol, config[:warning].to_s.to_i)
           ok 'All is well!'
         end
       end

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -60,6 +60,11 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          description: 'Operator used to compare data with warning/critial values. Can be set to "le" (<=), "ge" (>=).',
          default: 'ge'
 
+  option :convert_timeticks,
+         short: '-T (true|false)',
+         description: 'Convert SNMP::TimeTick to Integer for comparisons',
+         default: 'false'
+
   option :timeout,
          short: '-t timeout (seconds)',
          default: '1'
@@ -87,10 +92,16 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
           critical "Value: #{vb.value} failed to match Pattern: #{config[:match]}"
         end
       else
-        critical 'Critical state detected' if "#{vb.value}".to_i.send(symbol, "#{config[:critical]}".to_i)
+        snmp_value =  if config[:convert_timeticks] && config[:convert_timeticks] == 'true'
+                        vb.value.is_a?(SNMP::TimeTicks) ? vb.value.to_i : vb.value
+                      else
+                        vb.value
+                      end
+
+        critical 'Critical state detected' if "#{snmp_value}".to_i.send(symbol, "#{config[:critical]}".to_i)
         # #YELLOW
-        warning 'Warning state detected' if ("#{vb.value}".to_i.send(symbol, "#{config[:warning]}".to_i)) && !("#{vb.value}".to_i.send(symbol, "#{config[:critical]}".to_i)) # rubocop:disable LineLength
-        unless "#{vb.value}".to_i.send(symbol, "#{config[:warning]}".to_i)
+        warning 'Warning state detected' if ("#{snmp_value}".to_i.send(symbol, "#{config[:warning]}".to_i)) && !("#{snmp_value}".to_i.send(symbol, "#{config[:critical]}".to_i)) # rubocop:disable LineLength
+        unless "#{snmp_value}".to_i.send(symbol, "#{config[:warning]}".to_i)
           ok 'All is well!'
         end
       end

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -65,7 +65,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          long: '--convert-timeticks',
          description: 'Convert SNMP::TimeTicks to Integer for comparisons',
          boolean: true,
-         default: 'false'
+         default: false
 
   option :timeout,
          short: '-t timeout (seconds)',


### PR DESCRIPTION
Devices that provide `SNMP::TimeTick` values for OIDs are difficult to compare using `>=` or `<=` given the odd output (e.g., `00:26:00.00` rather than a more handy `156000`). This commit allows specifying `-T true` to convert these (using `#to_i`) to `Integer` for easier comparison.
