### PR TITLE
Remove 1.9.3 support, add 2.3 & 2.4 testing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 - [ ] RuboCop passes
 
-- [ ] Existing tests pass 
+- [ ] Existing tests pass
 
 #### New Plugins
 
@@ -24,5 +24,5 @@
 
 #### Purpose
 
-#### Known Compatablity Issues
+#### Known Compatability Issues
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,11 @@ cache:
 install:
 - bundle install
 rvm:
-- 1.9.3
 - 2.0
 - 2.1
 - 2.2
+- 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
@@ -26,8 +27,9 @@ deploy:
   on:
     tags: true
     all_branches: true
-    rvm: 1.9.3
     rvm: 2.0
     rvm: 2.1
     rvm: 2.2
+    rvm: 2.3.0
+    rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-snmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- Ruby 2.3.0 testing
+- Ruby 2.4.1 testing
+
+### Breaking Changes
+- Dropped Ruby 1.9.3 support
+
+### Fixed
+- PR template spelling
 
 ## [0.2.0] - 2016-08-10
 ### Added

--- a/Rakefile
+++ b/Rakefile
@@ -6,15 +6,6 @@ require 'rubocop/rake_task'
 require 'yard'
 require 'yard/rake/yardoc_task'
 
-desc 'Don\'t run Rubocop for unsupported versions'
-begin
-  args = if RUBY_VERSION >= '2.0.0'
-           [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]
-         else
-           [:spec, :make_bin_executable, :yard]
-         end
-end
-
 YARD::Rake::YardocTask.new do |t|
   OTHER_PATHS = %w().freeze
   t.files = ['lib/**/*.rb', 'bin/**/*.rb', OTHER_PATHS]
@@ -44,4 +35,4 @@ task :check_binstubs do
   end
 end
 
-task default: args
+task default: [:spec, :make_bin_executable, :yard, :rubocop, :check_binstubs]

--- a/sensu-plugins-snmp.gemspec
+++ b/sensu-plugins-snmp.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.platform               = Gem::Platform::RUBY
   s.post_install_message   = 'You can use the embedded Ruby by setting EMBEDDED_RUBY=true in /etc/default/sensu'
   s.require_paths          = ['lib']
-  s.required_ruby_version  = '>= 1.9.3'
+  s.required_ruby_version  = '>= 2.0.0'
 
   s.summary                = 'Sensu plugins for SNMP'
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})


### PR DESCRIPTION
## Pull Request Checklist

RE https://github.com/sensu-plugins/sensu-plugins-feature-requests/issues/27

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Drop Ruby 1.9.3 as it is no longer supported.
Add testin for Ruby versions 2.3.0 & 2.4.1

#### Known Compatablity Issues

