### PR TITLE
added reverse option for critical and warning thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachangelog.com/)
 
 ## [Unreleased]
+### Added
+- check-snmp.rb: Option to reverse login in critical/warning thresholds
 
 ## [1.0.0] - 2017-07-04
 ### Added

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -46,6 +46,12 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          short: '-c critical',
          default: '20'
 
+  option :reverse,
+         short: '-r',
+         description: 'Revese the logic of the test for warning and critical thresholds',
+         boolean: true,
+         default: false
+
   option :match,
          short: '-m match',
          description: 'Regex pattern to match against returned value'
@@ -94,7 +100,11 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
     rescue => e
       unknown "An unknown error occured: #{e.inspect}"
     end
-    operators = { 'le' => :<=, 'ge' => :>= }
+    if config[:reverse]
+      operators = { 'le' => :>=, 'ge' => :<= }
+    else
+      operators = { 'le' => :<=, 'ge' => :>= }
+    end
     symbol = operators[config[:comparison]]
 
     response.each_varbind do |vb|

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -100,11 +100,11 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
     rescue => e
       unknown "An unknown error occured: #{e.inspect}"
     end
-    if config[:reverse]
-      operators = { 'le' => :>=, 'ge' => :<= }
-    else
-      operators = { 'le' => :<=, 'ge' => :>= }
-    end
+    operators = if config[:reverse]
+                  { 'le' => :>=, 'ge' => :<= }
+                else
+                  { 'le' => :<=, 'ge' => :>= }
+                end
     symbol = operators[config[:comparison]]
 
     response.each_varbind do |vb|


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?**
NO

#### General

- [ x ] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [ N/A ] Update README with any necessary configuration snippets

- [ N/A ] Binstubs are created if needed

- [ x ] RuboCop passes

- [ x ] Existing tests pass

#### New Plugins

- [ N/A ] Tests

- [ N/A ] Add the plugin to the README

- [ N/A ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
To provide the capability to reverse the logic used when evaluating critical and warning states.
Use case: SNMP provides a value as an output but you want to be alerted if that value is below a threshold, rather than above it.
Example: Power Socket Voltage: 240v, Warn when below 230V, Critical when below 210v.

#### Known Compatability Issues
None known
