### PR TITLE
Add port option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Which is based on [Keep A Changelog](http://keepachangelog.com/)
 ### Fixed
 - typos in changelog and pr template (@majormoses)
 
+### Added
+- check-snmp-disk.rb: added `--port|-P` option (@freepenguins)
+- metrics-snmp.rb: added `--port|-P` option (@freepenguins)
+- metrics-snmp-bulk.rb: added `--port|-P` option (@freepenguins)
+- metrics-snmp-if.rb: added `--port|-P` option (@freepenguins)
+
+### Fixed
+- check-snmp.rb: changed port option from `-p` to `-P` to avoid confusion with prefix (@freepenguins)
+
 ## [1.1.0] - 2017-10-04
 ### Added
 - check-snmp.rb: added `--port` option (@freepenguins)

--- a/bin/check-snmp-disk.rb
+++ b/bin/check-snmp-disk.rb
@@ -42,6 +42,10 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          default: '127.0.0.1',
          description: 'SNMP hostname'
 
+  option :port,
+         short: '-P port',
+         default: '161'
+
   option :community,
          short: '-C snmp community',
          default: 'public',
@@ -96,6 +100,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
     dev_used_oid = base_oid + '.6'
     begin
       manager = SNMP::Manager.new(host: config[:host].to_s,
+                                  port: config[:port].to_i,
                                   community: config[:community].to_s,
                                   version: config[:snmp_version].to_sym,
                                   timeout: config[:timeout].to_i)

--- a/bin/check-snmp-disk.rb
+++ b/bin/check-snmp-disk.rb
@@ -44,6 +44,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
 
   option :port,
          short: '-P port',
+         long: '--port PORT',
          default: '161'
 
   option :community,

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -31,7 +31,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          default: '127.0.0.1'
 
   option :port,
-         short: '-p port',
+         short: '-P port',
          default: '161'
 
   option :community,

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -30,6 +30,10 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
          short: '-h host',
          default: '127.0.0.1'
 
+  option :port,
+         short: '-p port',
+         default: '161'
+
   option :community,
          short: '-C snmp community',
          default: 'public'
@@ -81,6 +85,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
   def run
     begin
       manager = SNMP::Manager.new(host: config[:host].to_s,
+                                  port: config[:port].to_i,
                                   community: config[:community].to_s,
                                   version: config[:snmp_version].to_sym,
                                   timeout: config[:timeout].to_i)

--- a/bin/check-snmp.rb
+++ b/bin/check-snmp.rb
@@ -32,6 +32,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
 
   option :port,
          short: '-P port',
+         long: '--port PORT',
          default: '161'
 
   option :community,

--- a/bin/metrics-snmp-bulk.rb
+++ b/bin/metrics-snmp-bulk.rb
@@ -32,6 +32,7 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :port,
          short: '-P port',
+         long: '--port PORT',
          default: '161'
 
   option :community,

--- a/bin/metrics-snmp-bulk.rb
+++ b/bin/metrics-snmp-bulk.rb
@@ -30,6 +30,10 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
          default: '127.0.0.1',
          required: true
 
+  option :port,
+         short: '-P port',
+         default: '161'
+
   option :community,
          short: '-C snmp community',
          boolean: true,
@@ -86,6 +90,7 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
     mibs = config[:mibs].split(',')
     begin
       manager = SNMP::Manager.new(host: config[:host].to_s,
+                                  port: config[:port].to_i,
                                   community: config[:community].to_s,
                                   version: config[:snmp_version].to_sym,
                                   timeout: config[:timeout].to_i)

--- a/bin/metrics-snmp-if.rb
+++ b/bin/metrics-snmp-if.rb
@@ -54,6 +54,7 @@ class SNMPIfStatsGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :port,
          short: '-P port',
+         long: '--port PORT',
          default: '161'
 
   option :community,

--- a/bin/metrics-snmp-if.rb
+++ b/bin/metrics-snmp-if.rb
@@ -52,6 +52,10 @@ class SNMPIfStatsGraphite < Sensu::Plugin::Metric::CLI::Graphite
          default: '127.0.0.1',
          required: true
 
+  option :port,
+         short: '-P port',
+         default: '161'
+
   option :community,
          short: '-C snmp community',
          boolean: true,
@@ -138,7 +142,7 @@ class SNMPIfStatsGraphite < Sensu::Plugin::Metric::CLI::Graphite
     if_table_columns = if_table_common_columns +
                        (config[:low_capacity] ? if_table_LC_columns : if_table_HC_columns)
 
-    SNMP::Manager.open(host: config[:host].to_s, community: config[:community].to_s, version: config[:version]) do |manager|
+    SNMP::Manager.open(host: config[:host].to_s, port: config[:port].to_i, community: config[:community].to_s, version: config[:version]) do |manager|
       manager.walk(if_table_columns) do |row_array|
         # turn row (an array) into a hash for eaiser access to the columns
         row = Hash[*if_table_columns.zip(row_array).flatten]

--- a/bin/metrics-snmp.rb
+++ b/bin/metrics-snmp.rb
@@ -10,7 +10,7 @@
 #
 # USAGE:
 #
-#   check-snmp -h host -C community -O oid -p prefix -s suffix
+#   check-snmp -h host -P port -C community -O oid -p prefix -s suffix
 #
 # LICENSE:
 #   Copyright (c) 2013 Double Negative Limited
@@ -29,6 +29,10 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
          boolean: true,
          default: '127.0.0.1',
          required: true
+
+  option :port,
+         short: '-P port',
+         default: '161'
 
   option :community,
          short: '-C snmp community',
@@ -71,7 +75,7 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
   def run
     mibs = config[:mibs].split(',')
     begin
-      manager = SNMP::Manager.new(host: config[:host].to_s, community: config[:community].to_s, version: config[:snmp_version].to_sym)
+      manager = SNMP::Manager.new(host: config[:host].to_s, port: config[:port].to_i, community: config[:community].to_s, version: config[:snmp_version].to_sym)
       if config[:mibdir] && !mibs.empty?
         manager.load_modules(mibs, config[:mibdir])
       end

--- a/bin/metrics-snmp.rb
+++ b/bin/metrics-snmp.rb
@@ -32,6 +32,7 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   option :port,
          short: '-P port',
+         long: '--port PORT',
          default: '161'
 
   option :community,


### PR DESCRIPTION
## Pull Request Checklist

**Is this in reference to an existing issue?** No

#### General

- [X] Update Changelog following the conventions laid [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [X] Tests

```
 /opt/sensu/embedded/bin/metrics-snmp-if.rb --port 160 -h my.host.name -C public -v
{"ifIndex"=>#<SNMP::VarBind:0x000000007b68a8 @name=[1.3.6.1.2.1.2.2.1.1.1], @value=#....
```

#### Purpose

Saw my last PR was incomplete and possibly could add to confusion with --prefix|-p option, so I updated each of the plugins with --port|-P and added it to the change log.

Sorry for putting this in two separate PR's.

Thanks for the quick turn-around on the last one as well!
