### PR TITLE
Fixed StandardError typo

### DIFF
--- a/bin/metrics-snmp.rb
+++ b/bin/metrics-snmp.rb
@@ -85,7 +85,7 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
       response = manager.get([config[:objectid].to_s])
     rescue SNMP::RequestTimeout
       unknown "#{config[:host]} not responding"
-    rescue StandardEerror => e
+    rescue StandardError => e
       unknown "An unknown error occured: #{e.inspect}"
     end
     config[:host] = config[:host].tr('.', '_') if config[:graphite]


### PR DESCRIPTION
Caused: Check failed to run: uninitialized constant SNMPGraphite::StandardEerror

## Pull Request Checklist

**Is this in reference to an existing issue?**

#### General

- [ ] Update Changelog following the conventions laid [here](https://github.com/sensu-plugins/community/blob/master/HOW_WE_CHANGELOG.md)

- [ ] Update README with any necessary configuration snippets

- [ ] Binstubs are created if needed

- [ ] RuboCop passes

- [ ] Existing tests pass

#### New Plugins

- [ ] Tests

- [ ] Add the plugin to the README

- [ ] Does it have a complete header as outlined [here](http://sensu-plugins.io/docs/developer_guidelines.html#coding-style)

#### Purpose
Check failed to run: uninitialized constant SNMPGraphite::StandardEerror

#### Known Compatibility Issues
